### PR TITLE
fix(meta): update page title and open graph metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Naveen Kumar Pasupuleti | Salesforce QA Engineer</title>
+    <title>Naveen Kumar Pasupuleti | SDET</title>
     <meta
       name="description"
       content="Naveen Kumar Pasupuleti - Salesforce QA Engineer & Consultant at Capgemini"
     />
     <meta name="author" content="Naveen Kumar Pasupuleti" />
 
-    <meta
-      property="og:title"
-      content="Naveen Kumar Pasupuleti | Salesforce QA Engineer"
-    />
+    <meta property="og:title" content="Naveen Kumar Pasupuleti" />
     <meta
       property="og:description"
       content="Experienced Salesforce QA Engineer specializing in Service Cloud testing and validating Lightning Web Components to ensure reliability, performance, and seamless user experience."
@@ -50,7 +47,10 @@
       }
     </script>
 
-    <link rel="icon" type="image/svg+xml" href="/images/salesforce_logo.jpeg" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧑‍💻</text></svg>"
+    />
     <link rel="canonical" href="https://www.naveenpasupuleti.com/" />
   </head>
 


### PR DESCRIPTION
- Change page title from "Salesforce QA Engineer" to "SDET"
- Simplify og:title content to only "Naveen Kumar Pasupuleti"
- Replace favicon with a data URI emoji icon for improved loading
- Remove redundant meta tags related to previous job title