### PR TITLE
fix(index): scroll to home section on root path navigation

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -62,7 +62,7 @@ const Index: React.FC<IndexProps> = ({ section }) => {
         );
       }
 
-      // Scroll to section if specified
+      // Scroll to section if specified or scroll to home for root path
       if (section) {
         setTimeout(() => {
           const element = document.getElementById(
@@ -70,6 +70,17 @@ const Index: React.FC<IndexProps> = ({ section }) => {
           );
           if (element) {
             element.scrollIntoView({ behavior: "smooth" });
+          }
+        }, 100);
+      } else if (currentPath === "/") {
+        // Scroll to home section when navigating to root path
+        setTimeout(() => {
+          const homeElement = document.getElementById("home");
+          if (homeElement) {
+            homeElement.scrollIntoView({ behavior: "smooth" });
+          } else {
+            // Fallback: scroll to top if home element not found
+            window.scrollTo({ top: 0, behavior: "smooth" });
           }
         }, 100);
       }


### PR DESCRIPTION
- Add logic to scroll to #home element when current path is "/"
- Use smooth scrolling for better user experience
- Provide fallback to scroll to top if #home element is not found
- Maintain existing scroll to specified section functionality with delay of 100ms